### PR TITLE
Add max samples configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,5 +50,5 @@ All configurations you can include on `sidekiq_options`
 |---------------|------|---------|-------------|
 | `worker_stats_enabled` | boolean | false | Whether `worker_stats` should be enabled for this worker or not |
 | `worker_stats_mem_sleep ` | number | 5 | How many seconds to wait between each memory measurement |
-
+| `worker_stats_max_samples ` | number | 1000 | How many samples to keep for a given worker, it will delete the oldest samples first |
 

--- a/lib/sidekiq/worker_stats/configuration.rb
+++ b/lib/sidekiq/worker_stats/configuration.rb
@@ -3,6 +3,7 @@ module Sidekiq
     class Configuration
       DEFAULT_MEM_SLEEP = 5.freeze
       DEFAULT_ENABLED = false.freeze
+      DEFAULT_MAX_SAMPLES = 1000
 
       attr_reader :klass
 
@@ -17,7 +18,10 @@ module Sidekiq
       def enabled
         @klass.get_sidekiq_options['worker_stats_enabled'] || Sidekiq::WorkerStats::Configuration::DEFAULT_ENABLED
       end
+
+      def max_samples
+        @klass.get_sidekiq_options['worker_stats_max_samples'] || Sidekiq::WorkerStats::Configuration::DEFAULT_MAX_SAMPLES
+      end
     end
   end
 end
-


### PR DESCRIPTION
Relates to Issue #1 

This feature allows to keep a limited number of max samples, by default this number is 1000.

The method to remove old samples is ran each time a new one is inserted. It has got complexity `O(N)` where `N` is the total number of samples saved on redis. 