### PR TITLE
Fixed syntax errors on views

### DIFF
--- a/lib/sidekiq/worker_stats/views/worker_stats.erb
+++ b/lib/sidekiq/worker_stats/views/worker_stats.erb
@@ -35,8 +35,8 @@
             <tr>
               <td><a href="<%= root_path %>worker_stats/<%= key.to_s %>"><%= worker["class"].to_s %></a></td>
               <td><%= worker["args"] != nil ? worker["args"].join(", ") : "--" %></td>
-              <td><%= worker["start"] != nil ? Time.at(worker["start"]).strftime "%Y-%m-%d %H:%M:%S" : "--" %></td>
-              <td><%= worker["stop"] != nil ? Time.at(worker["stop"]).strftime "%Y-%m-%d %H:%M:%S" : "--" %></td>
+              <td><%= worker["start"] != nil ? Time.at(worker["start"]).strftime("%Y-%m-%d %H:%M:%S") : "--" %></td>
+              <td><%= worker["stop"] != nil ? Time.at(worker["stop"]).strftime("%Y-%m-%d %H:%M:%S") : "--" %></td>
               <td><%= "#{worker["walltime"].round(4)}" %></td>
               <td><%= "#{worker["mem"][worker["mem"].keys.min] / 1024 / 1024}" %></td>
               <td><%= "#{(worker["mem"].values.max / 1024 / 1024)}" %></td>

--- a/lib/sidekiq/worker_stats/views/worker_stats_single.erb
+++ b/lib/sidekiq/worker_stats/views/worker_stats_single.erb
@@ -34,11 +34,11 @@
             </tr>
             <tr>
               <td>Start</td>
-              <td><%= Time.at(@worker["start"]).strftime "%Y-%m-%d %H:%M:%S" %></td>
+              <td><%= @worker["start"] != nil ? Time.at(@worker["start"]).strftime("%Y-%m-%d %H:%M:%S") : "--"  %></td>
             </tr>
             <tr>
               <td>Stop</td>
-              <td><%= Time.at(@worker["stop"]).strftime "%Y-%m-%d %H:%M:%S" %></td>
+              <td><%= @worker["stop"] != nil ? Time.at(@worker["stop"]).strftime("%Y-%m-%d %H:%M:%S") : "--" %></td>
             </tr>
             <tr>
               <td>Runtime</td>


### PR DESCRIPTION
Also replicated the nil handlers to `worker_stats_single.erb`.

I was getting some errors while running the latest version:

```
SyntaxError: (erb):38: syntax error, unexpected tSTRING_BEG, expecting ':'
....at(worker["start"]).strftime "%Y-%m-%d %H:%M:%S" : "--" ).t...

...                               ^

(erb):38: syntax error, unexpected ':', expecting ')'
....strftime "%Y-%m-%d %H:%M:%S" : "--" ).to_s); _erbout.concat...

...                               ^

(erb):39: syntax error, unexpected tSTRING_BEG, expecting ':'
...e.at(worker["stop"]).strftime "%Y-%m-%d %H:%M:%S" : "--" ).t...

...                               ^

(erb):39: syntax error, unexpected ':', expecting ')'
....strftime "%Y-%m-%d %H:%M:%S" : "--" ).to_s); _erbout.concat...

...                               ^
```