### PR TITLE
Bump redis dependency version to < 5

### DIFF
--- a/lib/sidekiq/worker_stats/version.rb
+++ b/lib/sidekiq/worker_stats/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module WorkerStats
-    VERSION = '0.0.11'.freeze
+    VERSION = '0.0.12'.freeze
   end
 end

--- a/sidekiq-worker_stats.gemspec
+++ b/sidekiq-worker_stats.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'sidekiq/worker_stats/version'
@@ -19,11 +20,11 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths = ['lib']
 
+  s.add_dependency 'redis', '>= 3.3', '< 5'
   s.add_dependency 'sidekiq', '>= 4.1.4', '< 6'
-  s.add_dependency 'redis', '~> 3.3', '>= 3.3.0'
 
+  s.add_development_dependency 'byebug', '~> 3.5'
   s.add_development_dependency 'minitest', '~> 5.0'
   s.add_development_dependency 'rack-test', '~> 0.6'
-  s.add_development_dependency 'byebug', '~> 3.5'
   s.add_development_dependency 'rake', '~> 11.3'
 end


### PR DESCRIPTION
Fixes #18 

- https://github.com/redis/redis-rb/blob/master/CHANGELOG.md#401
- Also sorted dependencies alphabetically, as per Rubocop's suggestion

