### PR TITLE
Sidekiq 6 support

### DIFF
--- a/sidekiq-worker_stats.gemspec
+++ b/sidekiq-worker_stats.gemspec
@@ -21,9 +21,8 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'redis', '>= 3.3', '< 5'
-  s.add_dependency 'sidekiq', '>= 4.1.4', '< 6'
+  s.add_dependency 'sidekiq', '>= 4.1.4', '< 7.0'
 
-  s.add_development_dependency 'byebug', '~> 3.5'
   s.add_development_dependency 'minitest', '~> 5.0'
   s.add_development_dependency 'rack-test', '~> 0.6'
   s.add_development_dependency 'rake', '~> 11.3'


### PR DESCRIPTION
- Relaxed sidekiq version dependency in order to support [Sidekiq
6.0](https://github.com/mperham/sidekiq/blob/master/Changes.md#60).
- Bumped development ruby version to 2.6.4 (latest as of today)
- I've removed the byebug dependency, since it was using a very outdated
version (circa 2015) and it was causing build issues locally. Could've
bumped the version, but don't really want to break much here.